### PR TITLE
Add frosty resume popup for webhook replies

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,27 @@
             </form>
         </div>
     </main>
+    <div id="resume-popup-overlay" class="resume-popup-overlay" aria-hidden="true" role="dialog" aria-labelledby="resume-popup-title">
+        <div class="resume-popup-window" role="document">
+            <button id="resume-popup-close" class="resume-popup-close" type="button" aria-label="Fenster schließen">×</button>
+            <div class="resume-popup-heading">
+                <span class="resume-popup-icon" aria-hidden="true">❄️</span>
+                <div>
+                    <h2 id="resume-popup-title">Workflow-Antwort</h2>
+                    <p class="resume-popup-subtitle">Sende eine Nachricht zurück an deinen n8n-Workflow.</p>
+                </div>
+            </div>
+            <label class="sr-only" for="resume-popup-input">Antwortnachricht</label>
+            <textarea id="resume-popup-input" class="resume-popup-input" rows="4" placeholder="Hier deine Antwort eingeben..."></textarea>
+            <div class="resume-popup-actions">
+                <button id="resume-popup-send" class="resume-popup-send" type="button">
+                    <span aria-hidden="true">✉️</span>
+                    <span>Senden</span>
+                </button>
+            </div>
+            <p id="resume-popup-feedback" class="resume-popup-feedback" role="status" aria-live="polite"></p>
+        </div>
+    </div>
     <!-- Link zur ausgelagerten JavaScript-Datei -->
     <script src="script.js"></script>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -77,6 +77,42 @@ body {
     border-bottom-left-radius: 4px;
 }
 
+.message-text {
+    display: block;
+}
+
+.resume-button-wrapper {
+    margin-top: 0.75rem;
+}
+
+.resume-trigger-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(191, 219, 254, 0.6);
+    background: linear-gradient(135deg, rgba(191, 219, 254, 0.2), rgba(147, 197, 253, 0.35));
+    color: #dbeafe;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.25);
+    backdrop-filter: blur(4px);
+}
+
+.resume-trigger-button:hover,
+.resume-trigger-button:focus-visible {
+    transform: translateY(-1px) scale(1.02);
+    background: linear-gradient(135deg, rgba(191, 219, 254, 0.35), rgba(147, 197, 253, 0.5));
+    box-shadow: 0 12px 24px rgba(96, 165, 250, 0.35);
+}
+
+.resume-trigger-button:active {
+    transform: translateY(1px) scale(0.99);
+}
+
 .thinking-message {
     background-color: transparent !important;
     padding: 0 !important;
@@ -269,4 +305,153 @@ body {
     position: relative;
     z-index: 1;
   }
+}
+
+.resume-popup-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 100;
+    padding: 1.5rem;
+}
+
+.resume-popup-overlay.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.resume-popup-window {
+    position: relative;
+    width: min(100%, 380px);
+    background: linear-gradient(145deg, rgba(30, 41, 59, 0.95), rgba(59, 78, 102, 0.85));
+    border-radius: 18px;
+    border: 1px solid rgba(191, 219, 254, 0.4);
+    box-shadow: 0 20px 45px rgba(30, 64, 175, 0.35);
+    padding: 1.5rem;
+    color: #e5e7eb;
+}
+
+.resume-popup-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.resume-popup-icon {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    border-radius: 12px;
+    background: linear-gradient(160deg, rgba(191, 219, 254, 0.45), rgba(96, 165, 250, 0.3));
+    box-shadow: inset 0 0 15px rgba(255, 255, 255, 0.25);
+}
+
+.resume-popup-window h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #f8fafc;
+}
+
+.resume-popup-subtitle {
+    margin-top: 0.15rem;
+    color: #cbd5f5;
+    font-size: 0.85rem;
+}
+
+.resume-popup-input {
+    width: 100%;
+    min-height: 120px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    background: rgba(15, 23, 42, 0.55);
+    color: #f8fafc;
+    padding: 0.75rem;
+    resize: vertical;
+    font-family: 'Exo 2', sans-serif;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resume-popup-input:focus {
+    outline: none;
+    border-color: rgba(147, 197, 253, 0.9);
+    box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.45);
+}
+
+.resume-popup-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+}
+
+.resume-popup-send {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(59, 130, 246, 0.95));
+    color: #0f172a;
+    box-shadow: 0 15px 35px rgba(59, 130, 246, 0.45);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resume-popup-send:hover,
+.resume-popup-send:focus-visible {
+    transform: translateY(-1px) scale(1.02);
+    box-shadow: 0 18px 40px rgba(37, 99, 235, 0.5);
+}
+
+.resume-popup-send:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.resume-popup-feedback {
+    margin-top: 0.75rem;
+    min-height: 1.2rem;
+    font-size: 0.85rem;
+    color: #fca5a5;
+}
+
+.resume-popup-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(15, 23, 42, 0.4);
+    color: #f8fafc;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.resume-popup-close:hover,
+.resume-popup-close:focus-visible {
+    background: rgba(148, 163, 184, 0.45);
+    transform: scale(1.05);
+}
+
+body.resume-popup-open {
+    overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- add a frosty modal overlay that lets users answer webhook resume URLs without showing the raw link
- detect resume URLs in bot replies and present a dedicated trigger button linked to the popup
- style the new trigger and modal with frosty visuals and wire the popup to post replies back to the workflow

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7a3eefd6c8323b478564c6067bfea